### PR TITLE
Moved log line back to its place

### DIFF
--- a/src/ekaf_server.erl
+++ b/src/ekaf_server.erl
@@ -158,11 +158,11 @@ connected({timeout, Timer, <<"reconnect">>}, State)->
     gen_fsm:cancel_timer(Timer),
     fsm_next_state(connected, State);
 connected({tcp_closed,_}, State)->
-    ?INFO_MSG("connected/2 cant handle ~p",[_Event]),
     ?INFO_MSG("tcp_closed, reconnect",[]),
     gen_fsm:send_event(self(), connect),
     fsm_next_state(downtime, State);
 connected(_Event, State)->
+    ?INFO_MSG("connected/2 cant handle ~p",[_Event]),
     fsm_next_state(connected, State).
 
 ready(disconnected, State)->


### PR DESCRIPTION
Current tag 1.4 fails to compile
BTW why do you write "cant" and not "can't"? Will you accept a fix for it?