### PR TITLE
Fix a typo in callback name

### DIFF
--- a/include/ekaf_definitions.hrl
+++ b/include/ekaf_definitions.hrl
@@ -45,7 +45,7 @@
 -define(EKAF_CALLBACK_TIME_TO_CONNECT            , <<"ekaf_callback_time_to_connect">>).
 -define(EKAF_CALLBACK_TIME_DOWN                  , <<"ekaf_callback_time_down">>).
 -define(EKAF_CALLBACK_MAX_DOWNTIME_BUFFER_REACHED, <<"ekaf_callback_max_downtime_buffer_reached">>).
--define(EKAF_CALLBACK_MASSAGE_BUFFER             , <<"ekaf_callback_massage_buffer">>).
+-define(EKAF_CALLBACK_MESSAGE_BUFFER             , <<"ekaf_callback_message_buffer">>).
 
 
 %%======================================================================

--- a/src/ekaf_lib.erl
+++ b/src/ekaf_lib.erl
@@ -96,11 +96,11 @@ cursor(BatchEnabled,Messages,#ekaf_fsm{ to_buffer = _ToBuffer}=State)->
             %% only timeout sends messages every BufferTTL ms
             ekaf_lib:add_message_to_buffer(Messages,State);
         _ ->
-            Callback = ekaf_callbacks:find(?EKAF_CALLBACK_MASSAGE_BUFFER),
+            Callback = ekaf_callbacks:find(?EKAF_CALLBACK_MESSAGE_BUFFER),
             MessageSets = case Callback of
                               {CallbackModule,CallbackFunction} ->
                                   CallbackModule:CallbackFunction
-                                    (?EKAF_CALLBACK_MASSAGE_BUFFER,
+                                    (?EKAF_CALLBACK_MESSAGE_BUFFER,
                                      self(),
                                      ready,
                                      State,
@@ -134,11 +134,11 @@ spawn_inactivity_timeout(Messages, #ekaf_fsm{cor_id = CorId, client_id = ClientI
     Self = self(),
     spawn(
       fun()->
-              Callback = ekaf_callbacks:find(?EKAF_CALLBACK_MASSAGE_BUFFER),
+              Callback = ekaf_callbacks:find(?EKAF_CALLBACK_MESSAGE_BUFFER),
               MessageSets = case Callback of
                                 {CallbackModule,CallbackFunction} ->
                                     CallbackModule:CallbackFunction
-                                      (?EKAF_CALLBACK_MASSAGE_BUFFER,
+                                      (?EKAF_CALLBACK_MESSAGE_BUFFER,
                                        self(),
                                        ready,
                                        State,

--- a/test/ekaf_tests.erl
+++ b/test/ekaf_tests.erl
@@ -115,7 +115,7 @@ pick_test_() ->
       , ?_test(t_is_clean())
       ,{spawn, ?_test(?debugVal(t_change_kafka_config()))}
       , ?_test(t_is_clean())
-      ,{spawn, ?_test(?debugVal(t_massage_buffer_encode_messages_as_one_large_message()))}
+      ,{spawn, ?_test(?debugVal(t_message_buffer_encode_messages_as_one_large_message()))}
       , ?_test(t_is_clean())
       ]}}.
 
@@ -315,8 +315,8 @@ t_max_messages_to_save_during_kafka_downtime()->
     end,
     ok.
 
-t_massage_buffer_encode_messages_as_one_large_message()->
-    application:set_env(ekaf, ?EKAF_CALLBACK_MASSAGE_BUFFER, {ekaf_callbacks,encode_messages_as_one_large_message}),
+t_message_buffer_encode_messages_as_one_large_message()->
+    application:set_env(ekaf, ?EKAF_CALLBACK_MESSAGE_BUFFER, {ekaf_callbacks,encode_messages_as_one_large_message}),
     kafka_consumer ! {flush, 1, self()},
     Event1 = [{<<"id">>, 1}],
     Event2 = [{<<"id">>, 2}],
@@ -329,7 +329,7 @@ t_massage_buffer_encode_messages_as_one_large_message()->
         {flush, [X]}->
             ?assertEqual([[{<<"id">>, 1}], [{<<"id">>, 2}]], lists:usort(binary_to_term(X)))
     end,
-    application:set_env(ekaf, ?EKAF_CALLBACK_MASSAGE_BUFFER, undefined),
+    application:set_env(ekaf, ?EKAF_CALLBACK_MESSAGE_BUFFER, undefined),
     ok.
 
 t_is_clean()->


### PR DESCRIPTION
```
$ rebar get-deps clean compile eunit
...
All 30 tests passed.
```