### PR TITLE
Make callback names symbols, not strings

### DIFF
--- a/include/ekaf_definitions.hrl
+++ b/include/ekaf_definitions.hrl
@@ -35,17 +35,17 @@
 %%======================================================================
 %% Optional {Mod,Func} callbacks that can be set as an app env to ekaf
 %%======================================================================
--define(EKAF_CALLBACK_FLUSH                      , <<"ekaf_callback_flush">>).
--define(EKAF_CALLBACK_FLUSHED_REPLIED            , <<"ekaf_callback_flushed_replied">>).
--define(EKAF_CALLBACK_WORKER_DOWN                , <<"ekaf_callback_worker_down">>).
--define(EKAF_CALLBACK_WORKER_STILL_DOWN          , <<"ekaf_callback_worker_still_down">>).
--define(EKAF_CALLBACK_WORKER_UP                  , <<"ekaf_callback_worker_up">>).
--define(EKAF_CALLBACK_DOWNTIME_SAVED             , <<"ekaf_callback_downtime_saved">>).
--define(EKAF_CALLBACK_DOWNTIME_REPLAYED          , <<"ekaf_callback_downtime_replayed">>).
--define(EKAF_CALLBACK_TIME_TO_CONNECT            , <<"ekaf_callback_time_to_connect">>).
--define(EKAF_CALLBACK_TIME_DOWN                  , <<"ekaf_callback_time_down">>).
--define(EKAF_CALLBACK_MAX_DOWNTIME_BUFFER_REACHED, <<"ekaf_callback_max_downtime_buffer_reached">>).
--define(EKAF_CALLBACK_MASSAGE_BUFFER             , <<"ekaf_callback_massage_buffer">>).
+-define(EKAF_CALLBACK_FLUSH                      , ekaf_callback_flush).
+-define(EKAF_CALLBACK_FLUSHED_REPLIED            , ekaf_callback_flushed_replied).
+-define(EKAF_CALLBACK_WORKER_DOWN                , ekaf_callback_worker_down).
+-define(EKAF_CALLBACK_WORKER_STILL_DOWN          , ekaf_callback_worker_still_down).
+-define(EKAF_CALLBACK_WORKER_UP                  , ekaf_callback_worker_up).
+-define(EKAF_CALLBACK_DOWNTIME_SAVED             , ekaf_callback_downtime_saved).
+-define(EKAF_CALLBACK_DOWNTIME_REPLAYED          , ekaf_callback_downtime_replayed).
+-define(EKAF_CALLBACK_TIME_TO_CONNECT            , ekaf_callback_time_to_connect).
+-define(EKAF_CALLBACK_TIME_DOWN                  , ekaf_callback_time_down).
+-define(EKAF_CALLBACK_MAX_DOWNTIME_BUFFER_REACHED, ekaf_callback_max_downtime_buffer_reached).
+-define(EKAF_CALLBACK_MASSAGE_BUFFER             , ekaf_callback_massage_buffer).
 
 
 %%======================================================================


### PR DESCRIPTION
README relies on callback names as symbols, not strings.
Besides other ekaf settings are set using symbols, not strings.