### PR TITLE
Remove kafkamocker from app.src

### DIFF
--- a/src/ekaf.app.src
+++ b/src/ekaf.app.src
@@ -6,8 +6,7 @@
   {applications, [
                   kernel,
                   stdlib,
-                  gproc,
-                  kafkamocker
+                  gproc
                  ]},
   {modules,[ekaf, ekaf_sup, ekaf_protocol, ekaf_server, ekaf_protocol_metadata, ekaf_protocol_produce, ekaf_fsm, ekaf_lib, ekaf_utils, ekaf_picker, ekaf_server_lib, ekaf_socket, ekaf_callbacks, ekaf_demo]},
   {mod, { ekaf, []}}


### PR DESCRIPTION
There is no reason to start kafkamocker outside of testing. This removes kafkamocker from ekaf.app.src.