### PR TITLE
Switch worker picking to use gen_fsm instead of raw messages.

### DIFF
--- a/src/ekaf_lib.erl
+++ b/src/ekaf_lib.erl
@@ -75,8 +75,7 @@ common_async(Event, Topic, [{Key,Data}|Rest])->
                                    common_async(Event, Topic, {Key,Data})
                            end);
         TopicWorker ->
-            TopicWorker ! {pick, {Key,Data}, self()},
-            receive
+            case gen_fsm:sync_send_all_state_event(TopicWorker, {pick, {Key,Data}}, infinity) of
                 {ok,Worker} ->
                     case Worker of
                         {error,{retry,_N}} ->
@@ -135,8 +134,7 @@ common_sync(Event, Topic, [{Key,Data}|Rest]=AllData, Timeout, Results)->
                                    common_sync(Event, Topic, AllData, Timeout, Results)
                            end);
         TopicWorker ->
-            TopicWorker ! {pick, {Key,Data}, self()},
-            receive
+            case gen_fsm:sync_send_all_state_event(TopicWorker, {pick, {Key,Data}}, infinity) of
                 {ok,Worker} ->
                     case Worker of
                         {error,{retry,_N}} ->

--- a/src/ekaf_picker.erl
+++ b/src/ekaf_picker.erl
@@ -45,15 +45,15 @@ pick_async(Topic,Callback)->
     PrefixedTopic = ?PREFIX_EKAF(Topic),
     RegName = (catch gproc:where({n,l,PrefixedTopic})),
     TempCallback = fun(_With)->
-                           Pid = spawn(fun()->
-                                               receive
-                                                   {ok, Worker}->
-                                                       Callback(Worker);
-                                                   _UE ->
-                                                       {error, _UE}
-                                               end
-                                       end),
-                           gproc:send({n,l,PrefixedTopic}, {pick, Topic, Pid})
+                           spawn(fun() ->
+                                         Pid = gproc:where({n,l,PrefixedTopic}),
+                                         case gen_fsm:sync_send_all_state_event(Pid, {pick, Topic}, infinity) of
+                                             {ok, Worker} ->
+                                                 Callback(Worker);
+                                             _UE ->
+                                                 {error, _UE}
+                                         end
+                                 end)
                    end,
     case RegName of
         {'EXIT',Reason} ->

--- a/src/ekaf_server_lib.erl
+++ b/src/ekaf_server_lib.erl
@@ -67,7 +67,7 @@ handle_metadata_during_bootstrapping({metadata, resp, Metadata}, #ekaf_server{ t
 %%% External functions
 %%--------------------------------------------------------------------
 
-handle_pick({pick, Topic, _Callback}, _From, State)->
+handle_pick({pick, Topic}, _From, State)->
     case ekaf_picker:pick(Topic, undefined, sync, State#ekaf_server.strategy) of
         Pid when is_pid(Pid)->
             {Pid, State#ekaf_server{ worker = Pid}};


### PR DESCRIPTION
Fixes a problem where messages intended for the calling process
would be eaten by ekaf, and messages intended for ekaf would land
in the calling process.

Fixes https://github.com/helpshift/ekaf/issues/42