### PR TITLE
availability of a picked produce worker

### DIFF
--- a/src/ekaf_lib.erl
+++ b/src/ekaf_lib.erl
@@ -102,7 +102,12 @@ common_async(Event, Topic, Data)->
                                  {error,_}=E ->
                                      E;
                                  _ ->
-                                     gen_fsm:send_event(Worker, {Event, Data})
+                                     case is_process_alive(Worker) of
+                                         true ->
+                                             gen_fsm:send_event(Worker, {Event, Data});
+                                         false ->
+                                             common_async(Event, Topic, Data)
+                                     end
                              end
                      end),
     ok.


### PR DESCRIPTION
In the past year, I noticed that there is a problem for a consumer while pulling messages from a kafka broker, I could not get any messages. After a message system that rely on ekaf run for a few months, this kind of issue could show up again. Based on the result of tracing the function "handle_sync_event" of module "ekaf_server" in the emulator, I found that the producer worker has been picked is dead, it is a non-existed process, but it is still picked all the time.